### PR TITLE
Revert direct links of TimeInstant subclasses to String/Float

### DIFF
--- a/ontology.ttl
+++ b/ontology.ttl
@@ -861,7 +861,6 @@ Subclasses may have other ways to express the content.""" ;
 ###  http://odahub.io/ontology#TimeInstantISOT
 :TimeInstantISOT rdf:type owl:Class ;
                  rdfs:subClassOf :TimeInstant ,
-                                 :String,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty :has_format ;
                                    owl:hasValue :ISOT
@@ -871,7 +870,6 @@ Subclasses may have other ways to express the content.""" ;
 ###  http://odahub.io/ontology#TimeInstantMJD
 :TimeInstantMJD rdf:type owl:Class ;
                 rdfs:subClassOf :TimeInstant ,
-                                :Float,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :has_format ;
                                   owl:hasValue :MJD


### PR DESCRIPTION
Although this change seemed logical, class hierarchy in ontology needs to reflect the python class hierarchy in dispatcher.
Otherwise, I have no idea of how to consistently select proper class in `from_owl_uri`. 

The reason for this change was to allow datatype inference for these two classes. Need to add an adaptation to do this based on e.g. `:has_format` (in separate PRs, this one is a hot-fix for failing test)